### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -40,15 +40,12 @@ func organizationResource(
 		organization.Name,
 		organizationResourceType,
 		organization.ID,
-		[]resourceSdk.GroupTraitOption{
-			resourceSdk.WithGroupProfile(
-				map[string]interface{}{
-					"id":           organization.ID,
-					"name":         organization.Name,
-					"display_name": organization.DisplayName,
-				},
-			),
-		},
+		[]resourceSdk.GroupTraitOption{},
+		resourceSdk.WithResourceProfile(map[string]interface{}{
+			"id":           organization.ID,
+			"name":         organization.Name,
+			"display_name": organization.DisplayName,
+		}),
 		resourceSdk.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -39,15 +39,12 @@ func roleResource(role client2.Role, parentResourceID *v2.ResourceId) (*v2.Resou
 		role.Name,
 		roleResourceType,
 		role.ID,
-		[]resourceSdk.RoleTraitOption{
-			resourceSdk.WithRoleProfile(
-				map[string]interface{}{
-					"id":          role.ID,
-					"name":        role.Name,
-					"description": role.Description,
-				},
-			),
-		},
+		[]resourceSdk.RoleTraitOption{},
+		resourceSdk.WithResourceProfile(map[string]interface{}{
+			"id":          role.ID,
+			"name":        role.Name,
+			"description": role.Description,
+		}),
 		resourceSdk.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -38,8 +38,6 @@ func userResource(user client2.User, parentResourceID *v2.ResourceId) (*v2.Resou
 
 	userTraitOptions := []resourceSdk.UserTraitOption{
 		resourceSdk.WithEmail(user.Email, true),
-		resourceSdk.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
-		resourceSdk.WithUserProfile(profile),
 		resourceSdk.WithUserLogin(user.Email),
 	}
 
@@ -48,6 +46,8 @@ func userResource(user client2.User, parentResourceID *v2.ResourceId) (*v2.Resou
 		userResourceType,
 		user.UserId,
 		userTraitOptions,
+		resourceSdk.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
+		resourceSdk.WithResourceProfile(profile),
 		resourceSdk.WithParentResourceID(parentResourceID),
 	)
 }


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
